### PR TITLE
feat: agregar funcionalidad para marcar leads como pendientes y conta…

### DIFF
--- a/src/components/pages/leads-manager/ui/LeadDetailSheet.tsx
+++ b/src/components/pages/leads-manager/ui/LeadDetailSheet.tsx
@@ -1,0 +1,331 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CheckCircle2,
+  ChevronDown,
+  Circle,
+  MessageCircle,
+  X,
+} from 'lucide-react';
+import type { Lead } from '@/core/leads/entities/lead.entity.ts';
+import {
+  BUSINESS,
+  FOUND_US,
+  NEEDED_BY,
+  VOLUME_PURCHASE,
+} from '@/components/share/constants.ts';
+import { useModal } from '@/context/ModalContext.tsx';
+
+interface Props {
+  lead: Lead;
+  onContact: (lead: Lead) => void;
+  onMarkContacted: (lead: Lead) => Promise<void>;
+  onMarkPending: (lead: Lead) => Promise<void>;
+}
+
+const dateFormatter = new Intl.DateTimeFormat('es-MX', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+});
+
+const FIELD_CARD =
+  'rounded-xl bg-[#F6F3EF] border border-[#EFE7DE] px-3 py-2 min-h-[70px]';
+
+export const LeadDetailSheet = ({
+  lead,
+  onContact,
+  onMarkContacted,
+  onMarkPending,
+}: Props) => {
+  const modal = useModal();
+  const statusRef = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<'en-espera' | 'contactado'>(
+    lead.contactedAt ? 'contactado' : 'en-espera',
+  );
+  const [savingStatus, setSavingStatus] = useState(false);
+  const [statusOpen, setStatusOpen] = useState(false);
+
+  const statusSelectClass =
+    status === 'contactado'
+      ? 'bg-[#EAF3EE] text-[#2D5A3D]'
+      : 'bg-[#F7F4F0] text-[#3B2F24]';
+
+  const location = useMemo(() => {
+    const chunks = [lead.city, lead.region, lead.country].filter(Boolean);
+    return chunks.length > 0 ? chunks.join(', ') : '-';
+  }, [lead.city, lead.country, lead.region]);
+
+  useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (
+        statusRef.current &&
+        !statusRef.current.contains(event.target as Node)
+      ) {
+        setStatusOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('mousedown', handleOutsideClick);
+  }, []);
+
+  const handleStatusChange = async (value: 'en-espera' | 'contactado') => {
+    if (value === status) return;
+
+    setStatus(value);
+    setStatusOpen(false);
+    setSavingStatus(true);
+    try {
+      if (value === 'contactado') {
+        await onMarkContacted(lead);
+      } else {
+        await onMarkPending(lead);
+      }
+    } catch {
+      setStatus(status);
+    } finally {
+      setSavingStatus(false);
+    }
+  };
+
+  return (
+    <section className="flex h-full flex-col bg-white font-dm-sans">
+      <header className="flex items-center justify-between border-b border-[#EFE7DE] px-6 py-4">
+        <div>
+          <h2 className="text-[30px] leading-none text-[#3B2F24]">
+            Detalle del lead
+          </h2>
+          <p className="mt-1 text-[12px] text-[#9C9389] font-dm-sans">
+            Creado el {dateFormatter.format(new Date(lead.createdAt))}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={modal.close}
+          aria-label="Cerrar detalle"
+          className="rounded-full p-2 text-[#8B8176] transition-colors hover:bg-[#F6F3EF] hover:text-[#5F574E]"
+        >
+          <X size={18} />
+        </button>
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-6 pb-6 pt-5">
+        <div className="mb-5">
+          <label className="mb-1.5 block text-[10px] uppercase tracking-[0.12em] text-[#9C9389] font-dm-sans">
+            Estado
+          </label>
+          <div ref={statusRef} className="relative">
+            <button
+              type="button"
+              onClick={() => {
+                if (!savingStatus) setStatusOpen((prev) => !prev);
+              }}
+              disabled={savingStatus}
+              className={`flex w-full items-center justify-between px-10 py-3.5 pr-10 text-sm font-semibold transition-colors disabled:opacity-60 ${statusSelectClass} ${
+                statusOpen ? 'rounded-t-xl rounded-b-none' : 'rounded-xl'
+              }`}
+            >
+              <span>
+                {status === 'contactado' ? 'Contactado' : 'En espera'}
+              </span>
+            </button>
+
+            {status === 'contactado' ? (
+              <CheckCircle2
+                size={14}
+                className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[#2D5A3D]"
+              />
+            ) : (
+              <Circle
+                size={12}
+                className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[#5F574E]"
+              />
+            )}
+            <ChevronDown
+              size={15}
+              className={`pointer-events-none absolute right-3.5 top-1/2 -translate-y-1/2 text-[#8B8176] transition-transform ${
+                statusOpen ? 'rotate-180' : ''
+              }`}
+            />
+
+            {statusOpen && (
+              <div className="absolute left-0 right-0 top-full z-20 rounded-b-xl bg-[#F7F4F0] p-1 shadow-[0_10px_20px_rgba(40,30,20,0.10)]">
+                {[
+                  { value: 'en-espera' as const, label: 'En espera' },
+                  { value: 'contactado' as const, label: 'Contactado' },
+                ].map((option) => {
+                  const selected = status === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => handleStatusChange(option.value)}
+                      disabled={savingStatus}
+                      className={`flex w-full items-center gap-2 rounded-lg px-4 py-2.5 text-left text-sm font-semibold transition-colors ${
+                        selected
+                          ? 'bg-[#EAF3EE] text-[#2D5A3D]'
+                          : 'bg-[#F7F4F0] text-[#5F574E] hover:bg-[#EFE9E2]'
+                      }`}
+                    >
+                      {option.value === 'contactado' ? (
+                        <CheckCircle2
+                          size={14}
+                          className={
+                            selected ? 'text-[#2D5A3D]' : 'text-[#8B8176]'
+                          }
+                        />
+                      ) : (
+                        <Circle
+                          size={12}
+                          className={
+                            selected ? 'text-[#2D5A3D]' : 'text-[#8B8176]'
+                          }
+                        />
+                      )}
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-[0.12em] text-[#9C9389] font-dm-sans">
+              Informacion de contacto
+            </h3>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className={FIELD_CARD}>
+                <p className="text-[10px] uppercase tracking-widest text-[#9C9389]">
+                  Nombre
+                </p>
+                <p className="mt-1 text-sm text-[#3B2F24]">
+                  {lead.fullName || '-'}
+                </p>
+              </div>
+              <div className={FIELD_CARD}>
+                <p className="text-[10px] uppercase tracking-widest text-[#9C9389]">
+                  Email
+                </p>
+                <p className="mt-1 break-all text-sm text-[#3B2F24]">
+                  {lead.email || '-'}
+                </p>
+              </div>
+              <div className={FIELD_CARD}>
+                <p className="text-[10px] uppercase tracking-widest text-[#9C9389]">
+                  Empresa
+                </p>
+                <p className="mt-1 text-sm text-[#3B2F24]">
+                  {lead.businessName || '-'}
+                </p>
+              </div>
+              <div className={FIELD_CARD}>
+                <p className="text-[10px] uppercase tracking-widest text-[#9C9389]">
+                  Telefono
+                </p>
+                <p className="mt-1 text-sm text-[#3B2F24]">
+                  {lead.whatsapp || '-'}
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-[0.12em] text-[#9C9389] font-dm-sans">
+              Perfil de compra
+            </h3>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className={FIELD_CARD}>
+                <p className="text-[10px] uppercase tracking-widest text-[#9C9389]">
+                  Tipo de negocio
+                </p>
+                <p className="mt-1 text-sm text-[#3B2F24]">
+                  {BUSINESS[lead.businessType as keyof typeof BUSINESS] ||
+                    lead.businessType ||
+                    '-'}
+                </p>
+              </div>
+              <div className={FIELD_CARD}>
+                <p className="text-[10px] uppercase tracking-widest text-[#9C9389]">
+                  Origen
+                </p>
+                <p className="mt-1 text-sm text-[#3B2F24]">
+                  {FOUND_US[lead.foundUs as keyof typeof FOUND_US] ||
+                    lead.foundUs ||
+                    '-'}
+                </p>
+              </div>
+              <div className={FIELD_CARD}>
+                <p className="text-[10px] uppercase tracking-widest text-[#9C9389]">
+                  Volumen estimado
+                </p>
+                <p className="mt-1 text-sm text-[#3B2F24]">
+                  {VOLUME_PURCHASE[
+                    lead.volumePurchase as keyof typeof VOLUME_PURCHASE
+                  ] ||
+                    lead.volumePurchase ||
+                    '-'}
+                </p>
+              </div>
+              <div className={FIELD_CARD}>
+                <p className="text-[10px] uppercase tracking-widest text-[#9C9389]">
+                  Urgencia
+                </p>
+                <p className="mt-1 text-sm text-[#3B2F24]">
+                  {NEEDED_BY[lead.neededBy as keyof typeof NEEDED_BY] ||
+                    lead.neededBy ||
+                    '-'}
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-[0.12em] text-[#9C9389] font-dm-sans">
+              Ubicacion
+            </h3>
+            <div className={FIELD_CARD}>
+              <p className="text-sm text-[#3B2F24]">{location}</p>
+            </div>
+          </section>
+
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-[0.12em] text-[#9C9389] font-dm-sans">
+              Notas del cliente
+            </h3>
+            <div className="rounded-xl bg-[#F6F3EF] border border-[#EFE7DE] px-3 py-3 min-h-30">
+              <p className="text-sm leading-relaxed text-[#3B2F24] whitespace-pre-wrap">
+                {lead.products || 'No hay notas registradas.'}
+              </p>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <footer className="px-6 pb-4 pt-3">
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={() => onContact(lead)}
+            className="inline-flex w-full max-w-45 items-center justify-center gap-2 rounded-xl bg-[#2D5A3D] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#234832]"
+          >
+            <MessageCircle size={14} />
+            Contactar
+          </button>
+        </div>
+
+        <div className="mt-5 border-t border-[#EFE7DE] pt-4">
+          {/* <button
+            type="button"
+            onClick={modal.close}
+            className="text-[12px] font-dm-sans text-[#8B8176] transition-colors hover:text-[#5F574E]"
+          >
+            Volver
+          </button> */}
+        </div>
+      </footer>
+    </section>
+  );
+};

--- a/src/components/pages/leads-manager/ui/LeadsTable.tsx
+++ b/src/components/pages/leads-manager/ui/LeadsTable.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/pages/leads-manager/lib/scoreLeads.ts';
 import { useModal } from '@/context/ModalContext.tsx';
 import { DeleteLeadModal } from '@/components/pages/leads-manager/ui/DeleteLeadModal.tsx';
+import { LeadDetailSheet } from '@/components/pages/leads-manager/ui/LeadDetailSheet.tsx';
 
 const dateFormatter = new Intl.DateTimeFormat('es-MX', {
   day: '2-digit',
@@ -46,9 +47,17 @@ interface Props {
   leads: Lead[];
   onDelete: (id: string) => void;
   onContact: (lead: Lead) => void;
+  onMarkContacted: (lead: Lead) => Promise<void>;
+  onMarkPending: (lead: Lead) => Promise<void>;
 }
 
-export function LeadsTable({ leads, onDelete, onContact }: Props) {
+export function LeadsTable({
+  leads,
+  onDelete,
+  onContact,
+  onMarkContacted,
+  onMarkPending,
+}: Props) {
   const [page, setPage] = useState(1);
   const modal = useModal();
 
@@ -178,7 +187,22 @@ export function LeadsTable({ leads, onDelete, onContact }: Props) {
                         />
                       </button>
 
-                      <button>
+                      <button
+                        onClick={() =>
+                          modal.open({
+                            render: (
+                              <LeadDetailSheet
+                                lead={lead}
+                                onContact={onContact}
+                                onMarkContacted={onMarkContacted}
+                                onMarkPending={onMarkPending}
+                              />
+                            ),
+                            showCloseButton: false,
+                            variant: 'sheet-right',
+                          })
+                        }
+                      >
                         <Eye
                           size={20}
                           className="text-[#78716C] hover:text-[#162C14] transition-colors"

--- a/src/components/pages/leads-manager/ui/page.tsx
+++ b/src/components/pages/leads-manager/ui/page.tsx
@@ -51,6 +51,24 @@ export const LeadsManagerPage = () => {
     window.open(`https://wa.me/${number}`, '_blank');
   };
 
+  const handleMarkLeadContacted = async (lead: Lead) => {
+    await leadContainer.markLeadContacted.execute(lead.id);
+    setLeads((prev) =>
+      prev.map((item) =>
+        item.id === lead.id ? { ...item, contactedAt: Date.now() } : item,
+      ),
+    );
+  };
+
+  const handleMarkLeadPending = async (lead: Lead) => {
+    await leadContainer.markLeadPending.execute(lead.id);
+    setLeads((prev) =>
+      prev.map((item) =>
+        item.id === lead.id ? { ...item, contactedAt: undefined } : item,
+      ),
+    );
+  };
+
   return (
     <div className="p-4">
       <h1 className="text-2xl font-semibold font-cormorant mb-4">
@@ -61,6 +79,8 @@ export const LeadsManagerPage = () => {
         leads={filteredLeads}
         onDelete={handleDeleteLead}
         onContact={handleContactLead}
+        onMarkContacted={handleMarkLeadContacted}
+        onMarkPending={handleMarkLeadPending}
       />
       <ScoringRules />
     </div>

--- a/src/context/ModalContext.tsx
+++ b/src/context/ModalContext.tsx
@@ -8,6 +8,7 @@ import {
 import { X } from 'lucide-react';
 
 type ModalSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
+type ModalVariant = 'modal' | 'sheet-right';
 
 const sizeClass: Record<ModalSize, string> = {
   xs: 'max-w-xs w-full',
@@ -24,6 +25,7 @@ interface OpenOptions {
   onClose?: () => void;
   showCloseButton?: boolean;
   size?: ModalSize;
+  variant?: ModalVariant;
 }
 
 interface ModalContextType {
@@ -59,13 +61,21 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
       {children}
       {state.visible && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          className={`fixed inset-0 z-50 flex bg-black/50 ${
+            state.variant === 'sheet-right'
+              ? 'items-stretch justify-end'
+              : 'items-center justify-center'
+          }`}
           onClick={(e) => {
             if (e.target === e.currentTarget) close();
           }}
         >
           <div
-            className={`relative bg-white rounded-xl shadow-xl overflow-hidden ${sizeClass[state.size ?? 'md']}`}
+            className={`relative bg-white shadow-xl overflow-hidden ${
+              state.variant === 'sheet-right'
+                ? 'h-full w-full max-w-[560px] rounded-none md:rounded-l-2xl'
+                : `rounded-xl ${sizeClass[state.size ?? 'md']}`
+            }`}
           >
             {state.showCloseButton && (
               <button

--- a/src/core/containers/lead.container.ts
+++ b/src/core/containers/lead.container.ts
@@ -1,6 +1,7 @@
 import { LeadsRepository } from '@/core/database/repositories/leads.repository.ts';
 import { CreateLeadUseCase } from '@/core/leads/use-cases/create-lead.use-case.ts';
 import { MarkLeadContactedUseCase } from '@/core/leads/use-cases/mark-lead-contacted.use-case.ts';
+import { MarkLeadPendingUseCase } from '@/core/leads/use-cases/mark-lead-pending.use-case.ts';
 import { GetLeadsUseCase } from '@/core/leads/use-cases/get-leads.use-case.ts';
 import { GetLeadUbicationUseCase } from '@/core/leads/use-cases/get-lead-ubication.use-case.ts';
 import { DeleteLeadUseCase } from '@/core/leads/use-cases/delete-lead.use-case.ts';
@@ -10,6 +11,7 @@ const leadRepository = new LeadsRepository();
 export const leadContainer = {
   createLead: new CreateLeadUseCase(leadRepository),
   markLeadContacted: new MarkLeadContactedUseCase(leadRepository),
+  markLeadPending: new MarkLeadPendingUseCase(leadRepository),
   getLeads: new GetLeadsUseCase(leadRepository),
   getLeadUbication: new GetLeadUbicationUseCase(),
   deleteLead: new DeleteLeadUseCase(leadRepository),

--- a/src/core/database/repositories/leads.repository.ts
+++ b/src/core/database/repositories/leads.repository.ts
@@ -9,6 +9,7 @@ import {
   collection,
   deleteDoc,
   doc,
+  deleteField,
   getDoc,
   getDocs,
   orderBy,
@@ -78,6 +79,20 @@ export class LeadsRepository implements LeadRepository {
 
     await updateDoc(leadRef, {
       contactedAt: Date.now(),
+    });
+  }
+
+  async markPending(leadId: string): Promise<void> {
+    const leadRef = doc(db, this.COLLECTION, leadId);
+
+    const snapshot = await getDoc(leadRef);
+
+    if (!snapshot.exists()) {
+      throw new Error('Lead not found');
+    }
+
+    await updateDoc(leadRef, {
+      contactedAt: deleteField(),
     });
   }
 

--- a/src/core/leads/repositories/lead.repository.ts
+++ b/src/core/leads/repositories/lead.repository.ts
@@ -9,6 +9,7 @@ export interface LeadDateFilter {
 export interface LeadRepository {
   create(dto: CreateLeadDto): Promise<Lead>;
   markContacted(leadId: string): Promise<void>;
+  markPending(leadId: string): Promise<void>;
   getAll(filter?: LeadDateFilter): Promise<Lead[]>;
   delete(leadId: string): Promise<void>;
 }

--- a/src/core/leads/use-cases/mark-lead-pending.use-case.ts
+++ b/src/core/leads/use-cases/mark-lead-pending.use-case.ts
@@ -1,0 +1,13 @@
+import type { LeadRepository } from '@/core/leads/repositories/lead.repository.ts';
+
+export class MarkLeadPendingUseCase {
+  private leadRepository: LeadRepository;
+
+  constructor(leadRepository: LeadRepository) {
+    this.leadRepository = leadRepository;
+  }
+
+  execute(leadId: string): Promise<void> {
+    return this.leadRepository.markPending(leadId);
+  }
+}


### PR DESCRIPTION
Descripción del Pull Request
Esta entrega introduce la capacidad de gestionar clientes potenciales con el estado "pendiente" (no contactados) y añade una vista detallada mediante una hoja lateral (side sheet).

Cambios Realizados
1. Interfaz de Usuario (UI) y Gestión de Estado
Nuevo componente LeadDetailSheet: Se implementó una vista detallada que muestra información crítica: contacto, perfil de compra, ubicación y notas.

Gestión de Estados: Permite alternar entre "contactado" y "pendiente" con respuesta inmediata en la UI y manejo de errores.

Actualización en LeadsTable: Ahora, al visualizar un cliente, se dispara la apertura del LeadDetailSheet en el margen derecho.

LeadsManagerPage: Se integraron los controladores necesarios para gestionar el flujo de estados y se pasaron de forma descendente a la tabla.

2. Mejoras en el Contexto Modal
Variante "Hoja Derecha": Se extendió la lógica del contexto modal para admitir una nueva variante de visualización lateral, permitiendo que los modales emerjan desde la derecha en lugar del centro (layout tipo drawer).

3. Backend y Lógica de Dominio
LeadsRepository: Se añadió el método markPending para permitir la reversión del estado de contacto.

Caso de Uso MarkLeadPendingUseCase: Implementación de la lógica para marcar clientes como pendientes eliminando el campo contactedAt.

Inyección de Dependencias: Se registró el nuevo caso de uso en el contenedor principal para asegurar su disponibilidad en toda la app.

